### PR TITLE
added index: 16 and index: 12 for the special ps button on ds4s

### DIFF
--- a/mappings/ps4-chrome-linux.json
+++ b/mappings/ps4-chrome-linux.json
@@ -91,6 +91,9 @@
     "right trigger": {
       "index": 7
     },
+    "special": {
+      "index": 16
+    },
     "start": {
       "index": 9
     },

--- a/mappings/ps4-chrome-windows-osx.json
+++ b/mappings/ps4-chrome-windows-osx.json
@@ -97,6 +97,9 @@
     "right trigger": {
       "index": 7
     },
+    "special": {
+      "index": 16
+    },
     "start": {
       "index": 9
     },

--- a/mappings/ps4-ff-osx.json
+++ b/mappings/ps4-ff-osx.json
@@ -94,6 +94,9 @@
     "right trigger": {
       "index": 7
     },
+    "special": {
+      "index": 12
+    },
     "start": {
       "index": 9
     },


### PR DESCRIPTION
# Background
Provide a mapping for the PS button on DS4s

# Changes
- 12 on firefox on linux and osx
- 16 on chrome

# Reference
https://github.com/ericlathrop/html5-gamepad/issues/11