### PR TITLE
skip gamepads not present

### DIFF
--- a/lib/single-gamepad.js
+++ b/lib/single-gamepad.js
@@ -35,10 +35,10 @@ SingleGamepad.prototype.axis = function(name) {
     var index = mapping.index;
     return this.gamepad.axes[index];
   }
-  if (mapping.buttonPositive !== undefined && this.gamepad.buttons[mapping.buttonPositive].pressed) {
+  if (mapping.buttonPositive !== undefined && this.gamepad.buttons.length > mapping.buttonPositive && this.gamepad.buttons[mapping.buttonPositive].pressed) {
     return 1;
   }
-  if (mapping.buttonNegative !== undefined && this.gamepad.buttons[mapping.buttonNegative].pressed) {
+  if (mapping.buttonNegative !== undefined && this.gamepad.buttons.length > mapping.buttonNegative && this.gamepad.buttons[mapping.buttonNegative].pressed) {
     return -1;
   }
   return 0;
@@ -48,10 +48,10 @@ SingleGamepad.prototype.button = function(name) {
   if (!mapping) {
     return false;
   }
-  if (mapping.index !== undefined) {
+  if (mapping.index !== undefined && this.gamepad.buttons.length > mapping.index) {
     return this.gamepad.buttons[mapping.index].pressed;
   }
-  if (mapping.axis !== undefined) {
+  if (mapping.axis !== undefined && this.gamepad.axes.length > mapping.axis) {
     if (mapping.direction < 0) {
       return this.gamepad.axes[mapping.axis] < -0.75;
     } else {


### PR DESCRIPTION
Gamepads that were not attached would throw errors when looping through gamepads, where one gamepad was partially attached or not fully present.